### PR TITLE
Fix #128

### DIFF
--- a/lib/functions/global/cloud.ts
+++ b/lib/functions/global/cloud.ts
@@ -29,7 +29,7 @@ export async function getCloudFolder(
 	return body;
 }
 
-export const EdHeadersFile = {
+const EdHeadersFile = {
 	authority: "api.ecoledirecte.com",
 	accept: "application/json, text/plain, */*",
 	"user-agent":

--- a/lib/functions/global/cloud.ts
+++ b/lib/functions/global/cloud.ts
@@ -29,15 +29,11 @@ export async function getCloudFolder(
 	return body;
 }
 
-const EdHeadersFile = {
+export const EdHeadersFile = {
 	authority: "api.ecoledirecte.com",
-	"sec-ch-ua":
-		// eslint-disable-next-line quotes
-		'"Google Chrome";v="89", "Chromium";v="89", ";Not A Brand";v="99"',
 	accept: "application/json, text/plain, */*",
-	"sec-ch-ua-mobile": "?0",
 	"user-agent":
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
 	"content-type": "application/x-www-form-urlencoded",
 	origin: "https://www.ecoledirecte.com",
 	"sec-fetch-site": "same-site",


### PR DESCRIPTION
Token "expiration" was actually related to bad headers.
By the way, EcoleDirecte "fingerprints" its users with the user-agent header to limit token mugging.